### PR TITLE
Format prices consistently with a space before the amount

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
                     <img src="products/1.webp" alt="Cat Food package" class="card-img-top product-img">
                     <div class="card-body">
                         <h5 class="card-title">Cat Food</h5>
-                        <p class="card-text">R169.95</p>
+                        <p class="card-text">R 169.95</p>
                         <a href="#" class="btn btn-primary">Buy</a>
                     </div>
                 </div>
@@ -47,7 +47,7 @@
                     <img src="products/2.jpg" alt="Box of washing powder" class="card-img-top product-img">
                     <div class="card-body">
                         <h5 class="card-title">Washing Powder</h5>
-                        <p class="card-text">R52.99</p>
+                        <p class="card-text">R 52.99</p>
                         <a href="#" class="btn btn-primary">Buy</a>
                     </div>
                 </div>
@@ -57,7 +57,7 @@
                     <img src="products/3.png" alt="Roll of rubbish bags" class="card-img-top product-img">
                     <div class="card-body">
                         <h5 class="card-title">Rubbish Bags</h5>
-                        <p class="card-text">R35.99</p>
+                        <p class="card-text">R 35.99</p>
                         <a href="#" class="btn btn-primary">Buy</a>
                     </div>
                 </div>
@@ -67,7 +67,7 @@
                     <img src="products/4.jpg" alt="Dishwashing liquid bottle" class="card-img-top product-img">
                     <div class="card-body">
                         <h5 class="card-title">Dishwashing Liquid</h5>
-                        <p class="card-text">R32.99</p>
+                        <p class="card-text">R 32.99</p>
                         <a href="#" class="btn btn-primary">Buy</a>
                     </div>
                 </div>
@@ -77,7 +77,7 @@
                     <img src="products/5.jpg" alt="Pack of Oreo cookies" class="card-img-top product-img">
                     <div class="card-body">
                         <h5 class="card-title">Oreo</h5>
-                        <p class="card-text">R25.99</p>
+                        <p class="card-text">R 25.99</p>
                         <a href="#" class="btn btn-primary">Buy</a>
                     </div>
                 </div>
@@ -87,7 +87,7 @@
                     <img src="products/6.jpg" alt="Bag of coffee beans" class="card-img-top product-img">
                     <div class="card-body">
                         <h5 class="card-title">Coffee</h5>
-                        <p class="card-text">R165.99</p>
+                        <p class="card-text">R 165.99</p>
                         <a href="#" class="btn btn-primary">Buy</a>
                     </div>
                 </div>
@@ -97,7 +97,7 @@
                     <img src="products/7.jpg" alt="Carton of long life milk" class="card-img-top product-img">
                     <div class="card-body">
                         <h5 class="card-title">Long Life Milk</h5>
-                        <p class="card-text">R109.99</p>
+                        <p class="card-text">R 109.99</p>
                         <a href="#" class="btn btn-primary">Buy</a>
                     </div>
                 </div>
@@ -107,7 +107,7 @@
                     <img src="products/8.webp" alt="Dog food package" class="card-img-top product-img">
                     <div class="card-body">
                         <h5 class="card-title">Dog Food</h5>
-                        <p class="card-text">R149.99</p>
+                        <p class="card-text">R 149.99</p>
                         <a href="#" class="btn btn-primary">Buy</a>
                     </div>
                 </div>
@@ -117,7 +117,7 @@
                     <img src="products/9.jpg" alt="Pack of boerewors sausage" class="card-img-top product-img">
                     <div class="card-body">
                         <h5 class="card-title">Boerewors</h5>
-                        <p class="card-text">R69.99</p>
+                        <p class="card-text">R 69.99</p>
                         <a href="#" class="btn btn-primary">Buy</a>
                     </div>
                 </div>
@@ -127,7 +127,7 @@
                     <img src="products/10.png" alt="Bottle of brandy" class="card-img-top product-img">
                     <div class="card-body">
                         <h5 class="card-title">Brandy</h5>
-                        <p class="card-text">R189.99</p>
+                        <p class="card-text">R1 89.99</p>
                         <a href="#" class="btn btn-primary">Buy</a>
                     </div>
                 </div>


### PR DESCRIPTION
This PR formats the prices in the product cards consistently by adding a space before the amount for improved readability.
